### PR TITLE
Change source of bootstrap datepicker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/bootstrap-datepicker"]
 	path = lib/bootstrap-datepicker
-	url = git://github.com/eternicode/bootstrap-datepicker.git
+	url = git://github.com/teddyhwang/bootstrap-datepicker.git


### PR DESCRIPTION
The meteorite package points to a GitHub version of bootstrap datepicker that is a fork from the original.

The original is here: http://www.eyecon.ro/bootstrap-datepicker/

Updating the gitmodule to point to a GitHub repository that holds the original source code which has recently seen some good updates.
